### PR TITLE
カレンダーのバグ修正

### DIFF
--- a/src/shared/parts/button/submit-button.vue
+++ b/src/shared/parts/button/submit-button.vue
@@ -27,6 +27,7 @@ const emits = defineEmits<{
 .button-container {
   position: relative;
   display: flex;
+  word-break: break-all;
 
   &.loading {
     opacity: 0.5;

--- a/src/shared/parts/form/date-picker.vue
+++ b/src/shared/parts/form/date-picker.vue
@@ -3,6 +3,7 @@
  * @see {@link https://vue3datepicker.com/installation/}
  */
 import { computed } from "vue"
+import { format } from "date-fns"
 import VueDatePicker, { type VueDatePickerProps } from "@vuepic/vue-datepicker"
 import "@vuepic/vue-datepicker/dist/main.css"
 
@@ -66,7 +67,7 @@ const handleUpdate = (value: string) => {
 }
 
 const handleCalendar = (value: string) => {
-  emits("update", { target: { value } })
+  emits("update", { target: { value: format(value, "yyyy/MM/dd") } })
 }
 </script>
 

--- a/src/shared/parts/form/date-picker.vue
+++ b/src/shared/parts/form/date-picker.vue
@@ -64,6 +64,10 @@ const getDayClass = (date: Date) => {
 const handleUpdate = (value: string) => {
   emits("update", { target: { value } })
 }
+
+const handleCalender = (value: string) => {
+  emits("update", { target: { value } })
+}
 </script>
 
 <template>
@@ -71,6 +75,7 @@ const handleUpdate = (value: string) => {
     v-bind="config"
     v-model="model"
     :day-class="getDayClass"
+    @change="handleCalender"
     @update:model-value="handleUpdate"
   >
     <template #year="year">{{ year.text }}年</template>

--- a/src/shared/parts/form/date-picker.vue
+++ b/src/shared/parts/form/date-picker.vue
@@ -65,7 +65,7 @@ const handleUpdate = (value: string) => {
   emits("update", { target: { value } })
 }
 
-const handleCalender = (value: string) => {
+const handleCalendar = (value: string) => {
   emits("update", { target: { value } })
 }
 </script>
@@ -75,7 +75,7 @@ const handleCalender = (value: string) => {
     v-bind="config"
     v-model="model"
     :day-class="getDayClass"
-    @change="handleCalender"
+    @change="handleCalendar"
     @update:model-value="handleUpdate"
   >
     <template #year="year">{{ year.text }}年</template>


### PR DESCRIPTION
（レビュイー）カレンダーのバグを修正しました

- 参考
  - close #35 

- 原因
  - 書式設定漏れ（未設定の場合はライブラリのデフォルトであるyyyy-MM-ddになる）

- 対応
  - `yyyy/MM/dd` の書式を設定した